### PR TITLE
Update for JupyterLab 0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.15.0",
-    "@jupyterlab/docregistry": "^0.15.0",
-    "@jupyterlab/notebook": "^0.15.0",
-    "@jupyterlab/rendermime-interfaces": "^1.0.1",
-    "@jupyterlab/services": "^1.0.1",
+    "@jupyterlab/application": "^0.16.0",
+    "@jupyterlab/docregistry": "^0.16.0",
+    "@jupyterlab/notebook": "^0.16.0",
+    "@jupyterlab/rendermime-interfaces": "^1.0.7",
+    "@jupyterlab/services": "^2.0.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.5.0"
   },


### PR DESCRIPTION
Beta 2 of JupyterLab was recently released (v0.32) so the jupyterlab_3Dmol dependencies need updating to allow it to be installed.

This was basically just copied from https://github.com/bokeh/jupyterlab_bokeh/pull/37